### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Along with a working C++ compiler and GNU software development tools you will ne
   * ncurses-devel
   * libxml2-devel
   * readline-devel
+  * flex
+  * bison
+  
 
 ## Build steps
 


### PR DESCRIPTION
for InfiniDB (not InfiniDB MySQL) flex and bison are required on Ubuntu 16.04